### PR TITLE
fix(package): Bump to @benmvp/cli@4.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
       }
     },
     "@benmvp/cli": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@benmvp/cli/-/cli-4.0.3.tgz",
-      "integrity": "sha512-EubEt6C57VWPnDc49VXXy8J33GAt/6A0lZprABPcxKehmoaK394WtLWVhi19nJhOUGGkVcPGPKmMsDmTXaSFNw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@benmvp/cli/-/cli-4.0.4.tgz",
+      "integrity": "sha512-KwRSKgevP3vL8n58mO5DM5dhqD2mgwC8d15PFl7KmOK77/vVbW307yI1n3YgyA+Iok5bwn4I/GmHFSZ/9roPzA==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.2.0",
@@ -2388,9 +2388,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.176",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.176.tgz",
-      "integrity": "sha512-hsQ/BH6x2iCvJ7WOIbNTAlsT39vsVGIVoJJ9i6ZkGXUE2LdzWsNv0xJI2uZ5/Hkqv1oTTLxAYjbtGKVJzqYbjA==",
+      "version": "1.3.178",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.178.tgz",
+      "integrity": "sha512-1+JjL/6toGZqcA1hI1e/zH86r0+BxFvustlwymDLIcdGfsjgR4LF9CgAoyk77L36tzE8zBDMSNd6q7HU2QRlJg==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "integrate": "benmvp integrate"
   },
   "devDependencies": {
-    "@benmvp/cli": "^4.0.3"
+    "@benmvp/cli": "^4.0.4"
   },
   "engines": {
     "node": ">= 8"


### PR DESCRIPTION

This fixes an issue where `@babel/runtime` needed to be a regular dependency because the built CJS files were requiring files within it. The updated version for `@benmvp/cli` now inlines (and duplicates) those dependencies.