### PR TITLE
fix(types): Export TypeScript types

### DIFF
--- a/integration-tests/src/tests.spec.ts
+++ b/integration-tests/src/tests.spec.ts
@@ -4,6 +4,7 @@ import {
   getCacheDefeatStr,
   parseQuery,
   parseUrl,
+  UrlParams,
 } from 'url-lib'
 
 describe('formatQuery', () => {
@@ -148,6 +149,25 @@ describe('formatUrl', () => {
     )
 
     expect(url).toEqual('http://www.benmvp.com/search?sort=popular&type=all&results=20&category=holiday')
+  })
+
+  it('properly types function wrappers', () => {
+    const API_BASE = 'http://api.benmvp.com'
+    const buildUrl = (apiName: string, command: string, params: UrlParams): string => {
+      const apiUrl = formatUrl(`${API_BASE}/${apiName}`, [
+        {
+          cmd: command,
+          key: 'MW9S-E7SL-26DU-VV8V',
+        },
+        params,
+      ])
+
+      return apiUrl
+    }
+
+    expect(
+      buildUrl('events', 'get', {q: 'javascript', pg: 2})
+    ).toEqual('http://api.benmvp.com/events?cmd=get&key=MW9S-E7SL-26DU-VV8V&q=javascript&pg=2')
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export {default as parseQuery} from './parseQuery'
 export {default as parseUrl} from './parseUrl'
 export {default as formatQuery} from './formatQuery'
 export {default as formatUrl} from './formatUrl'
+
+export {UrlParamValue, UrlParams, NullableUrlParams} from './types'


### PR DESCRIPTION

When `formatUrl` (and probably other utilities) are wrapped in functions, those functions will likely take arguments that will be passed through to the utilities. This means that those arguments will need to be typed correctly. Typing as `Object` will not work, it needs to be `UrlParams` specifically.

So this PR just exports `UrlParams`, `UrlValue` & `NullableUrlParams` so that they can be used as necessary. I added an integration test for this as well. The test failed with `Object` and passes with the newly exported `UrlParams`.